### PR TITLE
Allow building with tasty-1.4

### DIFF
--- a/aig.cabal
+++ b/aig.cabal
@@ -56,8 +56,7 @@ test-suite aig-test
   build-depends:
     base == 4.*,
     aig,
-    tasty < 1.3,
-    -- tasty-ant-xml requires tasty < 1.2 to build
+    tasty < 1.5,
     tasty-ant-xml,
     tasty-quickcheck >= 0.8.1,
     QuickCheck >= 2.7


### PR DESCRIPTION
Modern versions of `tasty-ant-xml` build with `tasty-1.4.*`, so we can safely raise the upper version bounds on `tasty` now.