### PR TITLE
Fix -Wstar-is-type warnings

### DIFF
--- a/aig.cabal
+++ b/aig.cabal
@@ -35,8 +35,7 @@ library
   default-Language: Haskell2010
   ghc-options:      -Wall -fno-ignore-asserts
   build-depends:
-    base >= 4 && < 4.16,
-    base-compat >= 0.6.0 && < 0.12,
+    base >= 4.9 && < 4.16,
     containers >= 0.5.5,
     mtl,
     vector,

--- a/src/Data/AIG/Interface.hs
+++ b/src/Data/AIG/Interface.hs
@@ -63,7 +63,7 @@ import qualified Prelude as Prelude
 import Control.Applicative
 import Control.Monad hiding (fail)
 import Data.IORef
-import Prelude.Compat hiding (not, and, or, mapM)
+import Prelude hiding (not, and, or, mapM)
 import Test.QuickCheck (Gen, Arbitrary(..), generate, oneof, sized, choose)
 
 -- | Concrete datatype representing the ways

--- a/src/Data/AIG/Operations.hs
+++ b/src/Data/AIG/Operations.hs
@@ -14,7 +14,6 @@ that can be built from the primitive And-Inverter Graph interface.
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 module Data.AIG.Operations
   ( -- * Bitvectors
     BV
@@ -138,17 +137,14 @@ import Control.Exception (assert)
 import qualified Control.Monad hiding (fail)
 import Control.Monad.State hiding (zipWithM, replicateM, mapM, sequence, fail)
 import Data.Bits ((.|.), setBit, shiftL, testBit)
-#if MIN_VERSION_base(4,8,0)
 import qualified Data.Bits as Bits
-#endif
 
 import qualified Data.Vector as V
 import qualified Data.Vector.Generic.Mutable as MV
 
-import Prelude()
-import Prelude.Compat
+import Prelude
   hiding (and, concat, length, not, or, replicate, splitAt, tail, (++), take, drop, zipWith, mapM)
-import qualified Prelude.Compat as Prelude
+import qualified Prelude as Prelude
 
 import Data.AIG.Interface
 import Data.AIG.AddTree
@@ -1073,14 +1069,7 @@ countTrailingZeros g (BV v) = do
 --   This is the floor of the lg2 function.  We extend the function so
 --   intLog2_down 0 = -1.
 intLog2_down :: Int -> Int
-#if MIN_VERSION_base(4,8,0)
 intLog2_down x = (Bits.finiteBitSize x - 1) - Bits.countLeadingZeros x
-#else
-intLog2_down x
-   | x <= 0    = -1
-intLog2_down 1 =  0
-intLog2_down x =  1 + intLog2_down (x `div` 2)
-#endif
 
 -- | Given positive x, find the unique i such that: 2^(i-1) < x <= 2^i
 --   This is the ceiling of the lg2 function.

--- a/src/Data/AIG/Trace.hs
+++ b/src/Data/AIG/Trace.hs
@@ -22,6 +22,7 @@ module Data.AIG.Trace where
 
 import Prelude hiding (not, and, or)
 import Data.IORef
+import Data.Kind
 import Data.List (intersperse)
 import System.IO
 import Control.Exception
@@ -36,7 +37,7 @@ class Traceable l where
 
 newtype TraceLit l s = TraceLit { unTraceLit :: l s }
 
-data TraceGraph (l :: * -> * ) g s
+data TraceGraph (l :: Type -> Type) g s
    = TraceGraph
    { tGraph :: g s
    , tActive :: IORef (Maybe Handle)


### PR DESCRIPTION
As of GHC 9.0.1, `-Wall` enables `-Wstar-is-type`, which warns if `*` is used as a kind instead of `Type` (from `Data.Kind`). This patch fixes two `-Wstar-is-type` warnings in `Data.AIG.Trace`.

Since `Data.Kind` first debuted in `base-4.9.0.0` (GHC 8.0), I decided to avoid the use of CPP and raise the lower version bounds on `base` to `>= 4.9`. Now that `base-4.9` or later is required, the `base-compat` dependency is no longer necessary, so this PR removes it as well.