### PR TITLE
Replace `binary-parsers` dependency with `attoparsec`, allow building with GHC 9.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+dist-newstyle

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 dist-newstyle
+/cabal.project

--- a/aig.cabal
+++ b/aig.cabal
@@ -36,10 +36,9 @@ library
   default-Language: Haskell2010
   ghc-options:      -Wall -fno-ignore-asserts
   build-depends:
+    attoparsec,
     base >= 4.9 && < 4.16,
     bimap,
-    binary,
-    binary-parsers,
     bytestring,
     containers >= 0.5.5,
     mtl,

--- a/aig.cabal
+++ b/aig.cabal
@@ -37,7 +37,7 @@ library
   ghc-options:      -Wall -fno-ignore-asserts
   build-depends:
     attoparsec,
-    base >= 4.9 && < 4.16,
+    base >= 4.9 && < 4.17,
     bimap,
     bytestring,
     containers >= 0.5.5,

--- a/cabal.project.dist
+++ b/cabal.project.dist
@@ -1,0 +1,1 @@
+packages: .


### PR DESCRIPTION
This patch allows `aig` to build with GHC 9.2. The main changes required come from the last two patches in this PR, whose commit messages are:

# Replace binary-parsers dependency with attoparsec

`binary-parsers` does not build with GHC 9.2, and it is unclear if the library is actively maintained anymore. The only thing we are using `binary-parsers` for is to have parser combinators over lazy `ByteString`s, but one can just as well accomplish the same thing with `attoparsec`. This patch replaces `binary-parsers` with `attoparsec`.

Fixes #10.

# Allow building with base-4.16.* (GHC 9.2)