### PR TITLE
Support building with GHC 9.6

### DIFF
--- a/aig.cabal
+++ b/aig.cabal
@@ -37,7 +37,7 @@ library
   ghc-options:      -Wall -fno-ignore-asserts
   build-depends:
     attoparsec,
-    base >= 4.9 && < 4.18,
+    base >= 4.9 && < 4.19,
     bimap,
     bytestring,
     containers >= 0.5.5,

--- a/src/Data/AIG/Operations.hs
+++ b/src/Data/AIG/Operations.hs
@@ -135,7 +135,9 @@ module Data.AIG.Operations
 import Control.Applicative hiding (empty)
 import Control.Exception (assert)
 import qualified Control.Monad hiding (fail)
-import Control.Monad.State hiding (zipWithM, replicateM, mapM, sequence, fail)
+import Control.Monad (foldM, forM_, join, unless)
+import Control.Monad.IO.Class (MonadIO(..))
+import Control.Monad.State (StateT(..), evalStateT)
 import Data.Bits ((.|.), setBit, shiftL, testBit)
 import qualified Data.Bits as Bits
 import Data.Maybe (isJust)


### PR DESCRIPTION
GHC 9.6 bundles `mtl-2.3.*`, which no longer re-exports `Control.Monad` and `Control.Monad.IO.Class` from `Control.Monad.State`. This patch uses explicit imports to fix the build.