### PR TITLE
Allow building with GHC 9.12

### DIFF
--- a/aig.cabal
+++ b/aig.cabal
@@ -37,7 +37,7 @@ library
   ghc-options:      -Wall -fno-ignore-asserts
   build-depends:
     attoparsec,
-    base >= 4.9 && < 4.21,
+    base >= 4.9 && < 4.22,
     bimap,
     bytestring,
     containers >= 0.5.5,


### PR DESCRIPTION
All that is required is lifting the upper version bounds on `base`.